### PR TITLE
Add modern player variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Demonstration web based player (HTML5 audio player) for IceCast servers. Using H
 - Demonstrating embedded mode (iframe)
 - Tested in firefox, chrome, and android browser.
 - Volume control
+- Modern variant with volume slider (see `modern.html`)

--- a/css/modern.css
+++ b/css/modern.css
@@ -1,0 +1,37 @@
+body{
+    font-family: Arial, sans-serif;
+    background:#111;
+    color:#fff;
+    margin:0;
+    height:100vh;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+}
+.playerBox{
+    background:#222;
+    padding:20px;
+    border-radius:8px;
+    width:300px;
+    text-align:center;
+}
+.buttons{
+    background:none;
+    border:none;
+    color:#fff;
+    font-size:2em;
+    padding:0 0.5em;
+    cursor:pointer;
+}
+.buttons.play:disabled,
+.buttons.stop:disabled{
+    color:#666;
+}
+#volumeSlider{
+    width:100%;
+    margin-top:10px;
+}
+.infoDiv,.statusDiv{
+    margin-top:10px;
+    font-size:1em;
+}

--- a/js/audioplayer.js
+++ b/js/audioplayer.js
@@ -142,7 +142,7 @@ var rbplayer={
         }
     },
     volumeString: function(){
-        return "Volume: " + rbplayer.player.volume*100 + "%";
+        return "Volume: " + Math.round(rbplayer.player.volume*100) + "%";
     },
     setVolumeButtons: function(){
         var volUp=document.getElementById("volUp");  

--- a/js/audioplayer.js
+++ b/js/audioplayer.js
@@ -34,6 +34,7 @@ var rbplayer={
     playButton: null,
     stopButton: null,
     pauseInterval: null,
+    volumeSlider: null,
     forceDecodeUtf8: false,
     setForceDecodeUtf8: function(){
         rbplayer.forceDecodeUtf8 = true;
@@ -156,17 +157,32 @@ var rbplayer={
     volUp: function(){
         if(rbplayer.player.volume<1){
             rbplayer.setPausedTimer();
-            rbplayer.player.volume=Math.round((rbplayer.player.volume+0.1)*10)/10;
-            rbplayer.setStausText(rbplayer.volumeString());
-            rbplayer.setVolumeButtons();
+            rbplayer.setVolume(Math.round((rbplayer.player.volume+0.1)*10)/10);
         }
-    },  
+    },
     volDown: function (){
         if(0<rbplayer.player.volume){
-            rbplayer.setPausedTimer();        
-            rbplayer.player.volume=Math.round((rbplayer.player.volume-0.1)*10)/10;        
-            rbplayer.setStausText(rbplayer.volumeString());
-            rbplayer.setVolumeButtons();        
+            rbplayer.setPausedTimer();
+            rbplayer.setVolume(Math.round((rbplayer.player.volume-0.1)*10)/10);
+        }
+    },
+    setVolume: function(value){
+        value=Math.max(0, Math.min(1, value));
+        rbplayer.player.volume=value;
+        rbplayer.setStausText(rbplayer.volumeString());
+        rbplayer.setVolumeButtons();
+        if(rbplayer.volumeSlider!=null){
+            rbplayer.volumeSlider.value=Math.round(value*100);
+        }
+    },
+    bindVolumeSlider: function(id){
+        rbplayer.volumeSlider=document.getElementById(id);
+        if(rbplayer.volumeSlider!=null){
+            rbplayer.volumeSlider.value=Math.round(rbplayer.player.volume*100);
+            rbplayer.volumeSlider.addEventListener('input', function(e){
+                rbplayer.setPausedTimer();
+                rbplayer.setVolume(e.target.value/100);
+            });
         }
     },
     forceSongTitle: function(){

--- a/modern.html
+++ b/modern.html
@@ -5,7 +5,7 @@
     <title>Modern RockBoxRadio Player</title>
     <script type="text/javascript" src="./js/audioplayer.js"></script>
     <link rel="stylesheet" type="text/css" href="./css/modern.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p1Cm3N1Xa76tbyG9ly1bs9xeqKxn30L9PMUk4z7ZSN7zjsFvdcT+kEcL50DJBSNgnob0GmSp2T5cU4gnGUd2IQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://kit.fontawesome.com/ca12700626.js" crossorigin="anonymous"></script>
 </head>
 <body onload="
     rbplayer.setup('https://vps.vyata.hu:9011','/stream?type=.mp3','RockBoxRadio',0);
@@ -23,6 +23,7 @@
             <div id="infoDiv" class="infoDiv"></div>
             <div id="statusDiv" class="statusDiv" style="display:block;"></div>
         </div>
+		<div id="actionDiv" class="actionDiv"><h6 id="caption"></h6></div>
     </div>
 </body>
 </html>

--- a/modern.html
+++ b/modern.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Modern RockBoxRadio Player</title>
+    <script type="text/javascript" src="./js/audioplayer.js"></script>
+    <link rel="stylesheet" type="text/css" href="./css/modern.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p1Cm3N1Xa76tbyG9ly1bs9xeqKxn30L9PMUk4z7ZSN7zjsFvdcT+kEcL50DJBSNgnob0GmSp2T5cU4gnGUd2IQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body onload="
+    rbplayer.setup('https://vps.vyata.hu:9011','/stream?type=.mp3','RockBoxRadio',0);
+    rbplayer.setupPlayer();
+    rbplayer.bindVolumeSlider('volumeSlider');
+">
+    <audio id="radio" preload="metadata">Your browser does not support the audio element.</audio>
+    <div id="playerBox" class="playerBox">
+        <div class="mainControls">
+            <button id="playButton" onclick="rbplayer.playRock()" type="button" class="buttons play"><i class="fas fa-play"></i></button>
+            <button id="stopButton" onclick="rbplayer.pauseRock()" type="button" class="buttons stop"><i class="fas fa-stop"></i></button>
+            <input type="range" id="volumeSlider" min="0" max="100" step="1">
+        </div>
+        <div class="info">
+            <div id="infoDiv" class="infoDiv"></div>
+            <div id="statusDiv" class="statusDiv" style="display:block;"></div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `modern.html` page with a minimal dark theme
- support a range slider for volume via new `css/modern.css`
- extend `audioplayer.js` with slider support
- document new page in README

## Testing
- `tidy -errors -q modern.html`

------
https://chatgpt.com/codex/tasks/task_e_6840253a4aac832ba09f2024cc5371b7